### PR TITLE
style: group plugin configs by category

### DIFF
--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -101,6 +101,7 @@ return {
             capabilities = vim.tbl_deep_extend("force", capabilities, require("blink.cmp").get_lsp_capabilities())
 
             local servers = {
+                -- systems
                 lua_ls = {
                     settings = {
                         Lua = {
@@ -113,13 +114,16 @@ return {
                 bashls = {},
                 clangd = {},
                 rust_analyzer = {},
-                jsonls = {},
-                yamlls = {},
-                cssls = {},
+                -- web
+                ts_ls = {},
                 html = {},
+                cssls = {},
                 tailwindcss = {},
                 emmet_language_server = {},
-                ts_ls = {},
+                -- data
+                jsonls = {},
+                yamlls = {},
+                -- tools
                 oxfmt = {},
                 oxlint = {},
             }

--- a/lua/plugins/nvim-treesitter.lua
+++ b/lua/plugins/nvim-treesitter.lua
@@ -6,20 +6,25 @@ return {
         config = function()
             local config = require("nvim-treesitter")
             config.install({
+                -- systems
                 "lua",
                 "c",
                 "rust",
+                -- vim
                 "vim",
                 "vimdoc",
+                -- web
                 "javascript",
                 "jsx",
                 "typescript",
                 "tsx",
                 "html",
                 "css",
+                -- data
                 "json",
                 "toml",
                 "yaml",
+                -- ops
                 "bash",
                 "dockerfile",
                 "gitcommit",


### PR DESCRIPTION
Group treesitter parsers and LSP servers into labeled categories (systems, web, data, ops/tools) for easier scanning and maintenance.